### PR TITLE
Handling empty brackets

### DIFF
--- a/examples/main/in.abell
+++ b/examples/main/in.abell
@@ -34,5 +34,7 @@
         `)
     }}
   </div>
+  Empty bracets check:
+  <div>{{ }}</div>
 </body>
 </html>

--- a/src/render.js
+++ b/src/render.js
@@ -37,7 +37,11 @@ function render(
       // Its a comment! e.g. \{{ print this as it is }}
       // Ignore the match that starts with slash '\' and return the same value without slash
       value = match[0].slice(1);
-    } else if (match[1].match(/} ?=/g) !== null) {
+    }else if(match[0].match(/\{{.\s*}}/)){
+      //removes empty brackets. 
+      //e.g. <div>{{ }}</div> renders <div></div>
+      value = '';
+    }else if (match[1].match(/} ?=/g) !== null) {
       // Condition to check if the block has destructuring
 
       // destructured elements need to be executed line by line.

--- a/src/render.js
+++ b/src/render.js
@@ -37,11 +37,11 @@ function render(
       // Its a comment! e.g. \{{ print this as it is }}
       // Ignore the match that starts with slash '\' and return the same value without slash
       value = match[0].slice(1);
-    }else if(match[0].match(/\{{.\s*}}/)){
-      //removes empty brackets. 
-      //e.g. <div>{{ }}</div> renders <div></div>
+    } else if (match[0].match(/\{{.\s*}}/)) {
+      // removes empty brackets.
+      // e.g. <div>{{ }}</div> renders <div></div>
       value = '';
-    }else if (match[1].match(/} ?=/g) !== null) {
+    } else if (match[1].match(/} ?=/g) !== null) {
       // Condition to check if the block has destructuring
 
       // destructured elements need to be executed line by line.

--- a/tests/render.spec.js
+++ b/tests/render.spec.js
@@ -49,6 +49,11 @@ describe('render() - renders abellTemplate into HTML Text', () => {
     );
   });
 
+  // eslint-disable-next-line max-len
+  it('should not throw error and return null value if empty brackets is passed', () => {
+    expect(render('{{ }}', {})).to.equal('');
+  });
+
   // error handlers
 
   // eslint-disable-next-line max-len


### PR DESCRIPTION
Fix #15 , Empty brackets (i.e. <div> {{ }} </div>) will now not throw error and renders <div></div> instead. Also added a test case to check empty brackets behavior. 