### PR TITLE
Scoped scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell-renderer",
-  "version": "0.3.3",
+  "version": "0.3.4-alpha.1",
   "description": "JavaScript based Template Engine. Compiles .abell files to .html",
   "main": "src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell-renderer",
-  "version": "0.3.4-alpha.1",
+  "version": "0.3.4-alpha.2",
   "description": "JavaScript based Template Engine. Compiles .abell files to .html",
   "main": "src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell-renderer",
-  "version": "0.3.4-alpha.2",
+  "version": "0.4.0-alpha.1",
   "description": "JavaScript based Template Engine. Compiles .abell files to .html",
   "main": "src/index.js",
   "bin": {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -56,6 +56,7 @@ function getStatementTypeMap(jsCode) {
       return astNode.type;
     });
   } catch (err) {
+    // errors are caught by the vm module so we let code continue anyway
     return ['ExpressionStatement'];
   }
 }

--- a/src/parsers/component-parser.js
+++ b/src/parsers/component-parser.js
@@ -177,7 +177,7 @@ function parseComponent(
     return {
       component: path.basename(abellComponentPath),
       componentPath: abellComponentPath,
-      content: isCss ? content : '{' + content + '}',
+      content,
       attributes: parseAttributes(contentMatch[1])
     };
   };

--- a/src/parsers/component-parser.js
+++ b/src/parsers/component-parser.js
@@ -8,7 +8,8 @@ const {
   execRegexOnAll,
   normalizePath,
   prefixHtmlTags,
-  getAbellComponentTemplate
+  getAbellComponentTemplate,
+  isInsideAbellBlock
 } = require('../utils/general-utils.js');
 
 /**
@@ -41,9 +42,16 @@ function componentTagTranspiler(abellTemplate) {
 
   let lastIndex = 0;
   for (const componentMatch of componentMatches) {
+    const isInsideBlock = isInsideAbellBlock(
+      abellTemplate,
+      componentMatch.index
+    );
+
     newAbellTemplate +=
       abellTemplate.slice(lastIndex, componentMatch.index) +
-      `{{ ${componentMatch[1]}(${componentMatch[2]}).renderedHTML }}`;
+      `${isInsideBlock ? '' : '{{'} ${componentMatch[1]}(${
+        componentMatch[2]
+      }).renderedHTML ${isInsideBlock ? '' : '}}'}`;
 
     lastIndex = componentMatch[0].length + componentMatch.index;
   }

--- a/src/utils/general-utils.js
+++ b/src/utils/general-utils.js
@@ -46,6 +46,23 @@ function getAbellInBuiltSandbox(options, transformations = {}) {
 }
 
 /**
+ * Checks if the given index comes inside Abell Block
+ * @param {string} abellBlockText abell template
+ * @param {number} index current position index
+ * @return {boolean}
+ */
+function isInsideAbellBlock(abellBlockText, index) {
+  const beforeIndexTemplate = abellBlockText.slice(0, index);
+  const openBracketMatches = beforeIndexTemplate.match(/.?{{/gs);
+  const openBracketCount = (openBracketMatches || []).length;
+  const closeBracketCount = (beforeIndexTemplate.match(/}}/g) || []).length;
+  return (
+    openBracketCount > closeBracketCount &&
+    !openBracketMatches[openBracketMatches.length - 1].startsWith('\\')
+  );
+}
+
+/**
  * Captures groups from regex and executes RegEx.exec() function on all.
  *
  * @param {regex} regex - Regular Expression to execute on.
@@ -169,6 +186,7 @@ const colors = {
 module.exports = {
   execRegexOnAll,
   getAbellInBuiltSandbox,
+  isInsideAbellBlock,
   logWarning,
   normalizePath,
   getAbellComponentTemplate,

--- a/tests/__snapshots__/component-parser.spec.js.snap
+++ b/tests/__snapshots__/component-parser.spec.js.snap
@@ -22,9 +22,9 @@ exports[`parseComponent() should parse component and return a componentTree - Sa
 exports[`parseComponent() should parse component and return a componentTree - Sample.abell 2`] = `"div[data-abell-hKYKjJ]{color:#f30;}"`;
 
 exports[`parseComponent() should parse component and return a componentTree - Sample.abell 3`] = `
-"
+"{
   console.log(3);
-"
+}"
 `;
 
 exports[`parseComponent() should work for nested components - Parent.abell 1`] = `

--- a/tests/__snapshots__/component-parser.spec.js.snap
+++ b/tests/__snapshots__/component-parser.spec.js.snap
@@ -22,9 +22,9 @@ exports[`parseComponent() should parse component and return a componentTree - Sa
 exports[`parseComponent() should parse component and return a componentTree - Sample.abell 2`] = `"div[data-abell-hKYKjJ]{color:#f30;}"`;
 
 exports[`parseComponent() should parse component and return a componentTree - Sample.abell 3`] = `
-"{
+"
   console.log(3);
-}"
+"
 `;
 
 exports[`parseComponent() should work for nested components - Parent.abell 1`] = `


### PR DESCRIPTION
- Adds `scopedSelector` and `scopedSelectorAll` functions.
- Fix bug that stopped parsing of components inside block. In short, next code works now-
```vue
{{
  showNav ? <Nav /> : null
}}
```