### PR TITLE
Add Native Node features

### DIFF
--- a/examples/read-file/__snapshots__/read-file.spec.js.snap
+++ b/examples/read-file/__snapshots__/read-file.spec.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`examples/read-file should render csv data in out.html 1`] = `
+"hi, hello, nice
+haha, woop, lol"
+`;

--- a/examples/read-file/in.abell
+++ b/examples/read-file/in.abell
@@ -1,0 +1,6 @@
+{{ 
+  const fs = require('fs');
+  const path = require('path');
+}}
+
+{{ console.log(fs.readFileSync(path.join(__dirname, 'sample.csv'))) }}

--- a/examples/read-file/in.abell
+++ b/examples/read-file/in.abell
@@ -3,4 +3,4 @@
   const path = require('path');
 }}
 
-{{ console.log(fs.readFileSync(path.join(__dirname, 'sample.csv'))) }}
+{{ fs.readFileSync(path.join(__dirname, 'sample.csv'), 'utf-8') }}

--- a/examples/read-file/read-file.spec.js
+++ b/examples/read-file/read-file.spec.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const { buildAndGetSelector } = require('../../tests/utils/baseTestFramework');
+
+describe('examples/read-file', () => {
+  beforeAll(async () => {
+    await buildAndGetSelector({
+      exampleToRun: 'read-file',
+      outPath: path.join(__dirname, 'out.html')
+    });
+  });
+
+  it('should render csv data in out.html', () => {
+    expect(
+      fs.readFileSync(path.join(__dirname, 'out.html'), 'utf-8').trim()
+    ).toEqual('hi, hello, nice\nhaha, woop, lol');
+  });
+});

--- a/examples/read-file/read-file.spec.js
+++ b/examples/read-file/read-file.spec.js
@@ -14,6 +14,6 @@ describe('examples/read-file', () => {
   it('should render csv data in out.html', () => {
     expect(
       fs.readFileSync(path.join(__dirname, 'out.html'), 'utf-8').trim()
-    ).toEqual('hi, hello, nice\nhaha, woop, lol');
+    ).toMatchSnapshot();
   });
 });

--- a/examples/read-file/sample.csv
+++ b/examples/read-file/sample.csv
@@ -1,0 +1,2 @@
+hi, hello, nice
+haha, woop, lol

--- a/examples/with-components/components/Footer.abell
+++ b/examples/with-components/components/Footer.abell
@@ -2,6 +2,7 @@
 {{ 
   const testJSONImport = require('../data/test-json-import.json');
   const Button = require('./Button.abell');
+  console.log('filename', __filename);
 }}
 <template>
   <footer data-test="footer-component"> 

--- a/examples/with-components/components/Footer.abell
+++ b/examples/with-components/components/Footer.abell
@@ -2,7 +2,6 @@
 {{ 
   const testJSONImport = require('../data/test-json-import.json');
   const Button = require('./Button.abell');
-  console.log('filename', __filename);
 }}
 <template>
   <footer data-test="footer-component"> 

--- a/examples/with-components/index.js
+++ b/examples/with-components/index.js
@@ -8,7 +8,7 @@ const abellTemplate = fs.readFileSync(
   'utf-8'
 );
 
-const { html, components } = abellRenderer.render(
+const { html } = abellRenderer.render(
   abellTemplate,
   {
     foo: 'Hehhe'
@@ -20,8 +20,5 @@ const { html, components } = abellRenderer.render(
     basePath: __dirname
   }
 );
-
-console.log(html);
-console.dir(components, { depth: Infinity });
 
 fs.writeFileSync(path.join(__dirname, 'out.html'), html);

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,27 @@ const {
 } = require('./utils/general-utils.js');
 
 /**
+ *
+ * @typedef RenderedObject
+ * @property {string} html
+ * @property {Array} components
+ *
+ * @typedef RenderOptions
+ * @property {string} basePath
+ * @property {string} filename
+ * @property {boolean} allowRequire
+ * @property {boolean} allowComponents
+ *
+ */
+
+/**
  * Outputs vanilla html string when abell template and sandbox is passed.
  *
  * @param {String} abellTemplate - String of Abell File.
  * @param {Object} userSandbox
  * Object of variables. The template will be executed in context of this sandbox.
- * @param {Object} options additional options e.g ({basePath})
- * @return {String|Object} htmlTemplate
+ * @param {RenderOptions} options additional options.
+ * @return {String|RenderedObject} htmlTemplate
  */
 function render(abellTemplate, userSandbox = {}, options = {}) {
   options.basePath =

--- a/src/parsers/component-parser.js
+++ b/src/parsers/component-parser.js
@@ -114,6 +114,7 @@ function parseComponent(
   const basePath = path.dirname(abellComponentPath);
   const filename = path.relative(process.cwd(), abellComponentPath);
 
+  console.log('1', process.cwd());
   const newOptions = { ...options, basePath, filename };
   const transformations = {
     '.abell': (abellComponentPath) => {
@@ -150,6 +151,11 @@ function parseComponent(
     htmlComponentContent
   );
 
+  console.log('2', process.cwd());
+  console.log(
+    'componentHash',
+    normalizePath(path.relative(process.cwd(), abellComponentPath))
+  );
   // we use the relative path here so that hash doesn't change across machines
   const componentHash = hash(
     normalizePath(path.relative(process.cwd(), abellComponentPath))

--- a/src/parsers/component-parser.js
+++ b/src/parsers/component-parser.js
@@ -112,8 +112,9 @@ function parseComponent(
 ) {
   const components = [];
   const basePath = path.dirname(abellComponentPath);
+  const filename = path.relative(process.cwd(), abellComponentPath);
 
-  const newOptions = { ...options, basePath };
+  const newOptions = { ...options, basePath, filename };
   const transformations = {
     '.abell': (abellComponentPath) => {
       const abellComponentContent = getAbellComponentTemplate(
@@ -142,10 +143,7 @@ function parseComponent(
   const htmlComponentContent = require('../compiler.js').compile(
     abellComponentContent,
     sandbox,
-    {
-      ...options,
-      filename: path.relative(process.cwd(), abellComponentPath)
-    }
+    newOptions
   );
 
   const templateTag = /\<template\>(.*?)\<\/template\>/gs.exec(

--- a/src/utils/general-utils.js
+++ b/src/utils/general-utils.js
@@ -3,9 +3,12 @@ const path = require('path');
 const { ABELL_CSS_DATA_PREFIX } = require('../parsers/css-parser.js');
 
 /**
+ * @typedef {import('../index.js').RenderOptions} RenderOptions
+ */
+
+/**
  * Returns in-built functions from Abell
- * @param {object} options
- * @param {string} options.basePath
+ * @param {RenderOptions} options
  * @param {object} transformations
  * @return {any}
  */
@@ -13,7 +16,9 @@ function getAbellInBuiltSandbox(options, transformations = {}) {
   const builtInFunctions = {
     console: {
       log: console.log
-    }
+    },
+    __filename: path.resolve(options.filename),
+    __dirname: path.resolve(options.basePath)
   };
 
   if (options.allowRequire) {


### PR DESCRIPTION
- Adds `__dirname`, `__filename` variables with respect to the existing .abell file.
- ~Add `process` variable by default (Just like Node does!) and set working directory at top.~

~This will allow users to use the following syntax with paths being relative to the current file.~
~{{ fs.readFileSync('./hello.csv') }}~

Just realized, it is expected Node behavior to not have paths relative to files. Users can use `__dirname` to make sure paths are right. 
